### PR TITLE
fix: changed  genome download

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -29,7 +29,7 @@ resources:
   ref_spike:
     #if bowtie index is not avialable leave only "" , it will be created
     #otherwise provide the path to the folder containing bowtie index (and add the name of the index after the path)
-    index_spike: ".test/data/dm6_index/bowtie1_dm6_index"
+    index_spike: ""
     # ucsc genome name (e.g. hg38, mm10, etc)
     spike_assembly: dm6
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -20,7 +20,7 @@ resources:
     #if bowtie index is not available leave only "" , it will be created
     #otherwise provide the path to the folder containing bowtie index (and add the name of the index after the path)
     #PLEASE NOTE: the index must be created with the same version of bowtie as the one installed in the conda environment (1.3.0)
-    index: ".test/data/subset_GRCh38_bowtieIndex/subset_GRCh38_bowtieIndex" #THIS IS A TEST INDEX, do not use it for a real dataset
+    index: "" #THIS IS A TEST INDEX, do not use it for a real dataset
     # ucsc genome name (e.g. hg38, mm10, etc)
     assembly: hg38
     #blacklist regions (from https://github.com/Boyle-Lab/Blacklist/tree/master/lists)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -20,7 +20,7 @@ resources:
     #if bowtie index is not available leave only "" , it will be created
     #otherwise provide the path to the folder containing bowtie index (and add the name of the index after the path)
     #PLEASE NOTE: the index must be created with the same version of bowtie as the one installed in the conda environment (1.3.0)
-    index: "" #THIS IS A TEST INDEX, do not use it for a real dataset
+    index: ".test/data/subset_GRCh38_bowtieIndex/subset_GRCh38_bowtieIndex" #THIS IS A TEST INDEX, do not use it for a real dataset
     # ucsc genome name (e.g. hg38, mm10, etc)
     assembly: hg38
     #blacklist regions (from https://github.com/Boyle-Lab/Blacklist/tree/master/lists)
@@ -29,7 +29,7 @@ resources:
   ref_spike:
     #if bowtie index is not avialable leave only "" , it will be created
     #otherwise provide the path to the folder containing bowtie index (and add the name of the index after the path)
-    index_spike: ""
+    index_spike: ".test/data/dm6_index/bowtie1_dm6_index"
     # ucsc genome name (e.g. hg38, mm10, etc)
     spike_assembly: dm6
 

--- a/workflow/envs/genomepy.yaml
+++ b/workflow/envs/genomepy.yaml
@@ -1,6 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda
-  - nodefaults
-dependencies:
-  - genomepy =0.16.1

--- a/workflow/rules/references.smk
+++ b/workflow/rules/references.smk
@@ -21,27 +21,25 @@ rule return_genome_path:
 
 rule get_reference_genome:
     output:
-        faFile="resources/reference_genome/{assembly}/{assembly}.fa",
+        faFile="resources/reference_genome/{assembly}.fa",
     log:
         "{}results/logs/ref/get_reference_{{assembly}}.log".format(outdir),
     params:
         provider="ucsc",  # optional, defaults to ucsc. Choose from ucsc, ensembl, and ncbi
         assemblyRef=config["resources"]["ref"]["assembly"],
+        outDir="resources/reference_genome",
     cache: "omit-software"  # mark as eligible for between workflow caching
+    priority: 10
     conda:
-        "../envs/genomepy.yaml"
-    shell:
-        """
-        genomepy plugin enable blacklist
-        genomepy install {params.assemblyRef} -g resources/reference_genome \
-        --provider {params.provider} >>{log} 2>&1
-        """
+        "../envs/various.yaml"
+    script:
+        "../scripts/download_genome.py"
 
 
 rule create_bowtie_index_reference:
     input:
         expand(
-            "resources/reference_genome/{assembly}/{assembly}.fa",
+            "resources/reference_genome/{assembly}.fa",
             assembly=config["resources"]["ref"]["assembly"],
         ),
     output:
@@ -99,26 +97,25 @@ rule return_spike_path:
 
 rule get_spike_genome:
     output:
-        faFile="resources/spike_genome/{assemblySpike}/{assemblySpike}.fa",
+        faFile="resources/spike_genome/{assemblySpike}.fa",
     log:
         "{}results/logs/ref/get_spike_{{assemblySpike}}.log".format(outdir),
     params:
         provider="ucsc",  # optional, defaults to ucsc. Choose from ucsc, ensembl, and ncbi
-        spike_assembly=config["resources"]["ref_spike"]["spike_assembly"],
+        assembly=config["resources"]["ref_spike"]["spike_assembly"],
+        outDir="resources/spike_genome",
     cache: "omit-software"  # mark as eligible for between workflow caching
+    priority: 10
     conda:
-        "../envs/genomepy.yaml"
-    shell:
-        """
-        genomepy install {params.spike_assembly} -g resources/spike_genome \
-        --provider {params.provider} >>{log} 2>&1
-        """
+        "../envs/various.yaml"
+    script:
+        "../scripts/download_genome.py"
 
 
 rule create_bowtie_index_spike:
     input:
         expand(
-            "resources/spike_genome/{assemblySpike}/{assemblySpike}.fa",
+            "resources/spike_genome/{assemblySpike}.fa",
             assemblySpike=config["resources"]["ref_spike"]["spike_assembly"],
         ),
     output:

--- a/workflow/rules/references.smk
+++ b/workflow/rules/references.smk
@@ -26,7 +26,7 @@ rule get_reference_genome:
         "{}results/logs/ref/get_reference_{{assembly}}.log".format(outdir),
     params:
         provider="ucsc",  # optional, defaults to ucsc. Choose from ucsc, ensembl, and ncbi
-        assemblyRef=config["resources"]["ref"]["assembly"],
+        assembly=config["resources"]["ref"]["assembly"],
     cache: "omit-software"  # mark as eligible for between workflow caching
     priority: 10
     conda:

--- a/workflow/rules/references.smk
+++ b/workflow/rules/references.smk
@@ -27,7 +27,6 @@ rule get_reference_genome:
     params:
         provider="ucsc",  # optional, defaults to ucsc. Choose from ucsc, ensembl, and ncbi
         assemblyRef=config["resources"]["ref"]["assembly"],
-        outDir="resources/reference_genome",
     cache: "omit-software"  # mark as eligible for between workflow caching
     priority: 10
     conda:
@@ -103,7 +102,6 @@ rule get_spike_genome:
     params:
         provider="ucsc",  # optional, defaults to ucsc. Choose from ucsc, ensembl, and ncbi
         assembly=config["resources"]["ref_spike"]["spike_assembly"],
-        outDir="resources/spike_genome",
     cache: "omit-software"  # mark as eligible for between workflow caching
     priority: 10
     conda:

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -35,6 +35,20 @@ properties:
               - mm10
               - hg19
               - hg38
+      ref_spike:
+        type: object
+        properties:
+          spike_assembly:
+            type: string
+            enum:
+              - dm3
+              - dm6
+              - mm10
+              - mm9
+              - hg19
+              - hg38
+              - hs1
+
 
 # entries that have to be in the config file for successful validation
 required:

--- a/workflow/scripts/download_genome.py
+++ b/workflow/scripts/download_genome.py
@@ -40,7 +40,6 @@ def unzip_file(gz_file):
 
 assembly = snakemake.params.assembly
 provider = snakemake.params.provider
-genomes_dir = snakemake.params.outDir
 output = snakemake.output[0]
 
 #prepare the download url
@@ -48,7 +47,7 @@ base_url = "http://hgdownload.soe.ucsc.edu/goldenPath/{}/bigZips/{}.fa.gz"
 genome_url = base_url.format(assembly, assembly)
 
 #prepare the output file
-outFileGZ = "{}/{}.fa.gz".format(genomes_dir, assembly)
+outFileGZ = output + ".gz"
 
 if not os.path.exists(output):
     print("Downloading {}...".format(genome_url))

--- a/workflow/scripts/download_genome.py
+++ b/workflow/scripts/download_genome.py
@@ -1,0 +1,63 @@
+import requests
+import sys
+import os
+import gzip
+import shutil
+
+
+sys.stdout = open(snakemake.log[0], 'a')
+sys.stderr = sys.stdout
+
+
+def download_file(url, local_filename):
+    try:
+        with requests.get(url, stream=True) as r:
+            r.raise_for_status()
+            with open(local_filename, 'wb') as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    f.write(chunk)
+    except requests.exceptions.HTTPError as errh:
+        print("HTTP Error: {}".format(errh))
+    except requests.exceptions.ConnectionError as errc:
+        print("Error Connecting: {}".format(errc))
+    except requests.exceptions.Timeout as errt:
+        print("Timeout Error: {}".format(errt))
+    except requests.exceptions.RequestException as err:
+        print("RequestException: {}".format(err))
+    except Exception as e:
+        print("An error occurred: {}".format(e))
+
+
+
+def unzip_file(gz_file):
+    unzipped_file = gz_file.replace('.gz', '')
+    with gzip.open(gz_file, 'rb') as f_in:
+        with open(unzipped_file, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
+    os.remove(gz_file)
+    return unzipped_file
+
+
+assembly = snakemake.params.assembly
+provider = snakemake.params.provider
+genomes_dir = snakemake.params.outDir
+output = snakemake.output[0]
+
+#prepare the download url
+base_url = "http://hgdownload.soe.ucsc.edu/goldenPath/{}/bigZips/{}.fa.gz"
+genome_url = base_url.format(assembly, assembly)
+
+#prepare the output file
+outFileGZ = "{}/{}.fa.gz".format(genomes_dir, assembly)
+
+if not os.path.exists(output):
+    print("Downloading {}...".format(genome_url))
+    download_file(genome_url, outFileGZ)
+    print("Downloaded to {}".format(outFileGZ))
+    print("Unzipping {}...".format(outFileGZ))
+    unzipped_genome= unzip_file(outFileGZ)
+    print("Unzipped to {}".format(unzipped_genome))
+else:
+    print("{} already exists. Skipping download.".format(output))
+
+


### PR DESCRIPTION
- Fixed schema for spike-in genome: supported spike-in genomes are:    dm3 ,dm6, mm10,mm9 , hg19,hg38, hs1
- removed genomepy and used requests to download ucsc genomes